### PR TITLE
Update .gitattributes to set ico and jpg extensions as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,5 @@
 *.aar binary
 *.sar binary
 *.png binary
+*.jpg binary
+*.ico binary


### PR DESCRIPTION
Whilst attempting to build using maven running in a container on z/OS I hit two errors copying files because of the default file encoding tagging applied.  This was resolved by updating the .gitattributes file 